### PR TITLE
feat(resolve): allow state resolve values to be bound to the component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,25 +71,40 @@ module.exports.State = function State(stateName, options) {
       throw new Error("@State() must be placed after @Component()!");
     }
     Class.$initState = function(directiveName) {
-      var urlParams = (options.url.match(/:.*?(\/|$)/g) || []).map(function(match) {
-        return match.replace(/\/$/, '').replace(/^:/,'');
-      });
 
-      app.config(function($stateProvider) {
+      app.config(['$stateProvider', '$urlMatcherFactoryProvider', function($stateProvider, $urlMatcherFactoryProvider) {
+        var urlParams = $urlMatcherFactoryProvider.compile(options.url, options).parameters();
+
         var htmlName = camelCaseToDashCase(directiveName);
         // <my-directive param-one="$stateParams['paramOne']" param-two="$stateParams['paramTwo']">
         var attrValuePairs = urlParams.map(function(param) {
           return camelCaseToDashCase(param) + '="__$stateParams[\'' + param + '\']"';
         }).join(' ');
-        var template = '<' + htmlName + ' ' + attrValuePairs + '>';
+
+        var resolveKeys = options.resolve ? Object.keys(options.resolve) : [];
+        var resolveValuePairs = resolveKeys.map(function(resolveKey) {
+          return camelCaseToDashCase(resolveKey) + '="__resolveValues[\'' + resolveKey + '\']"';
+        });
+
+        var template = '<' + htmlName + ' ' + attrValuePairs + ' ' + resolveValuePairs + '>';
+
+        var controller = function($stateParams, $scope) {
+          $scope.__$stateParams = $stateParams;
+          $scope.__resolveValues = {};
+          var resolveValues = Array.prototype.slice.call(arguments, 2);
+          resolveValues.forEach(function(resolveValue, index) {
+            var resolveKey = resolveKeys[index];
+            $scope.__resolveValues[resolveKey] = resolveValue;
+          });
+        };
+
+        controller.$inject = ['$stateParams', '$scope'].concat(resolveKeys);
 
         $stateProvider.state(stateName, angular.merge({
-          controller: function($stateParams, $scope) {
-            $scope.__$stateParams = $stateParams;
-          },
+          controller: controller,
           template: template
         }, options));
-      });
+      }]);
     };
 
   };

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -37,14 +37,15 @@ describe('ngClassy', () => {
 
   it('Component with State should pass stateParams to component attributes', () => {
     @classy.Component({
-      template: '<div>param1={{vm.param1}}, param2={{vm.param2}}</div>',
+      template: '<div>param1={{vm.param1}}, param2={{vm.param2}}, param3={{vm.param3}}</div>',
       bind: {
         param1: '=',
-        param2: '='
+        param2: '=',
+        param3: '='
       }
     })
     @classy.State('superState', {
-      url: '/super/:param1/:param2'
+      url: '/super/:param1/:param2?param3'
     })
     class SuperComponent {
     }
@@ -54,12 +55,13 @@ describe('ngClassy', () => {
       $rootScope.$apply();
       $state.go('superState', {
         param1: 'valueOne',
-        param2: 'valueTwo'
+        param2: 'valueTwo',
+        param3: 'valueThree'
       });
       $rootScope.$apply();
       console.log(app);
       expect(app.find('super-component').length).to.equal(1);
-      expect(app.find('super-component').text()).to.equal('param1=valueOne, param2=valueTwo');
+      expect(app.find('super-component').text()).to.equal('param1=valueOne, param2=valueTwo, param3=valueThree');
     });
   });
 
@@ -71,4 +73,35 @@ describe('ngClassy', () => {
       }
     }).to.throw();
   });
+
+  it('should allow binding states resolves to the component', () => {
+
+    @classy.Component({
+      template: '<div>resolve1={{vm.resolve1}}</div>',
+      bind: {
+        resolve1: '='
+      }
+    })
+    @classy.State('resolveState', {
+      url: '/resolve',
+      resolve: {
+        resolve1: ($q) => {
+          return $q.when('resolveValueOne');
+        }
+      }
+    })
+    class ResolveComponent {
+    }
+
+    inject(($compile, $state, $rootScope) => {
+      let app = $compile('<div><ui-view></ui-view></div>')($rootScope);
+      $rootScope.$apply();
+      $state.go('resolveState');
+      $rootScope.$apply();
+      expect(app.find('resolve-component').length).to.equal(1);
+      expect(app.find('resolve-component').text()).to.equal('resolve1=resolveValueOne');
+    });
+
+  });
+
 });


### PR DESCRIPTION
I also used the `$urlMatcherFactoryProvider` service from the ui-router to extract url params so you can have `/:param1?param2` as the url and not have to rely on `$location` for getting `param2`.

Any problems / changes let me know :smile: 

Closes #4 